### PR TITLE
[#1] Use randomly generated password; No need to force password reset

### DIFF
--- a/controller/acp_upload_controller.php
+++ b/controller/acp_upload_controller.php
@@ -9,6 +9,7 @@
 
 namespace david63\bulkuseradd\controller;
 
+use Exception;
 use phpbb\config\config;
 use phpbb\cache\service;
 use phpbb\request\request;
@@ -308,15 +309,30 @@ class acp_upload_controller implements acp_upload_interface
 					}
 					else // We are OK to process the data
 					{
+						// Create random 16-character password
+						$passwordLength = 16;
+						$password = '';
+						try
+						{
+							$password = bin2hex(random_bytes($passwordLength / 2));
+						}
+						catch (Exception $e)
+						{
+							$validPasswordCharacters = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ`~!@#$%^&*()_-+=[]{}\|;:\'",<.>/?';
+							for ($i = 0; $i < $passwordLength; $i++)
+							{
+								$index = rand(0, strlen($validPasswordCharacters) - 1);
+								$password .= $validPasswordCharacters[$index];
+							}
+						}
+
 						$user_row = array(
 							'username'		=> $data[$username_column],
-							'user_password'	=> $this->passwords_manager->hash($data[$username_column]),
+							'user_password'	=> $this->passwords_manager->hash($password),
 							'user_email'	=> $data[$email_column],
 							'group_id'		=> $group_id,
 							'user_type'		=> USER_NORMAL,
 							'user_new'		=> 1,
-							// Set this to force password change when logging in
-							'user_bulk_add'	=> 1,
 						);
 
 						//Let's deal with the start date


### PR DESCRIPTION
This generates a random 16-character password for each new user. It will first attempt to create an 8-byte cryptographicly strongly random number and then convert it to hex (16 characters). That hex string will be used as the password.
If any errors occur during, it will resort to a brute force, not-so-cryptographically-strong, method that includes more character options, but is still the same length.

With the password being randomly generated and not saved anywhere, users will be forced to use the "Forgot my password" feature to log in - at which point there is no need to force new users to change their password on first login. For that reason, the force password change has been removed.

I've tested this on my own forum and it seems to have worked (users were created, I can not log in as them).